### PR TITLE
Implement test and fix for #8

### DIFF
--- a/lib/overrides.coffee
+++ b/lib/overrides.coffee
@@ -65,7 +65,7 @@ class Overrides
   #
   # Returns the default settings.
   getDefaults: ->
-    _.defaults(atom.config.getDefault("editor"), atom.config.get("editor"))
+    _.defaults(atom.config.get("editor"), atom.config.getDefault("editor"))
 
   # Gets the grammar's scope name for the given `EditorView`.
   #

--- a/spec/overrides-spec.coffee
+++ b/spec/overrides-spec.coffee
@@ -31,7 +31,7 @@ describe "Overrides", ->
       waitsForPromise -> atom.packages.activatePackage("language-ruby")
       waitsForPromise -> atom.packages.activatePackage("language-python")
 
-      atom.config.set("editor.tabLength", 2)
+      atom.config.set("editor.tabLength", 3)
       atom.config.set("overrides.scopes", allOverrides)
 
       editor = atom.workspace.openSync()


### PR DESCRIPTION
Had to completely rearrange the test framework because too much was interacting with the `EditorView` class to ignore it anymore. Found out from the [Find and Replace package](https://github.com/atom/find-and-replace/blob/master/spec/results-view-spec.coffee#L23-26) how to attach an `EditorView` to the headless test infrastructure. This slows down the tests, so I only implemented it for the tests that really needed it. (Hence why all the rearranging.)
